### PR TITLE
Fixed paths for pytest >= 2.9.2

### DIFF
--- a/Core/FUnitTest.py
+++ b/Core/FUnitTest.py
@@ -12,12 +12,7 @@ class FUnitTest:
         print '%s = unitTestDir' % unitTestDir
         print '%s = xmlResultFile' % xmlResultFile
 
-        if get_platform() == 'windows':
-            # paths with backslashes not supported by pytest
-            unitTestDir = unitTestDir.replace('\\', '/')
-            xmlResultFile = xmlResultFile.replace('\\', '/')
-
-        return pytest.main('\"' + unitTestDir + '\" ' + '-s --junitxml=\"' + xmlResultFile + '\"')
+        return pytest.main(unitTestDir + ' -s --junitxml=' + xmlResultFile)
 
     # invoque py.test with -v(verbose) option and --junitxml=titi2.xml(creating JUnitXML files)
     # pytest.main("test_sample.py -v --junitxml=titi2.xml")


### PR DESCRIPTION
Fixed pytest not supporting double quotes in paths. Requires pytest >= 2.9.2.
